### PR TITLE
PLANTE-1571: Skru av trace-logging i prod

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -4,8 +4,3 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: https://maskinporten.no/
-
-logging:
-  level:
-    org.springframework.security: TRACE
-    org.springframework.security.oauth2.server.resource.web.server: TRACE


### PR DESCRIPTION
Fjerner trace-logging på autentisering i prodmiljøet for å unngå for mye støy i loggene