### PR TITLE
PLANTE-1821: Kall til eppo timer ut

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ I Eppodatabasen er det laget et kodeverk for klassifisering av planter, og det s
 
 Det finnes flere måter å hente eppokoder for planter på, dokumentasjon til rest-api'et til eppo finnes her: https://data.eppo.int/documentation/rest Det er også mulig å manuelt søke på planter på nettsiden: https://gd.eppo.int/
 
-Det valideres om det er gyldige eppokoder som sendes inn, og det returneres feil dersom en eller flere eppokoder ikke finnes. Dette er bare testdata, så inntil videre er det ikke viktig hvilken eppokode som brukes.
+Det valideres om det er gyldige eppokoder som sendes inn, og det returneres feil dersom en eller flere eppokoder ikke finnes. så lenge det er testdata er det ikke viktig hvilken eppokode som brukes, men produksjonsdata må være riktige.
 
 Det finnes ikke eppokoder for alle plantearter, så det kan være tilfeller hvor man ikke klarer å angi eksakt hva som er sprøytet på. Da skal den nærmeste eppokoden i hierarkiet sendes inn, og så angis sort i feltet for 'sort'.
 

--- a/src/main/kotlin/no/mattilsynet/plantevernjournal/api/clients/EppoApiClient.kt
+++ b/src/main/kotlin/no/mattilsynet/plantevernjournal/api/clients/EppoApiClient.kt
@@ -13,8 +13,8 @@ import java.time.Duration
 
 @Component
 class EppoApiClient(
-    @Value("\${eppo.api.token}") private val eppoToken: String,
-    @Value("\${eppo.api.uri}") private val eppoUri: String,
+    @Value($$"${eppo.api.token}") private val eppoToken: String,
+    @Value($$"${eppo.api.uri}") private val eppoUri: String,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/no/mattilsynet/plantevernjournal/api/controllers/PlantevernjournalInnlesingController.kt
+++ b/src/main/kotlin/no/mattilsynet/plantevernjournal/api/controllers/PlantevernjournalInnlesingController.kt
@@ -46,7 +46,7 @@ class PlantevernjournalInnlesingController(
     @Operation(
         description = "Endepunkt for å sende inn informasjon om sprøyting på frø og formeringsmateriale",
     )
-    fun postFroeEllerFormeringsmateriale(
+    suspend fun postFroeEllerFormeringsmateriale(
         @AuthenticationPrincipal jwt: Jwt?,
         @Parameter(
             name = "froeEllerFormeringsMatrialeDto",
@@ -69,7 +69,7 @@ class PlantevernjournalInnlesingController(
         description = "Endepunkt for å sende inn informasjon om sprøyting som foregår innendørs, feks i et veksthus",
     )
     @PostMapping("/innendoersbruk", consumes = [MediaType.APPLICATION_JSON_VALUE])
-    fun postInnendoersBruk(
+    suspend fun postInnendoersBruk(
         @AuthenticationPrincipal jwt: Jwt?,
         @Parameter(
             name = "innendoersBrukDto",
@@ -92,7 +92,7 @@ class PlantevernjournalInnlesingController(
         description = "Endepunkt for å sende inn informasjon om sprøyting som skjer utendørs, feks på et jorde",
     )
     @PostMapping("/utendoersbruk", consumes = [MediaType.APPLICATION_JSON_VALUE])
-    fun postUtendoersBruk(
+    suspend fun postUtendoersBruk(
         @AuthenticationPrincipal jwt: Jwt?,
         @Parameter(
             name = "utendoersBrukDto",
@@ -181,7 +181,7 @@ class PlantevernjournalInnlesingController(
 
     private val objectMapper = jacksonObjectMapper()
 
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNUSED")
     private fun Jwt.getPaaVegneAvFraToken() =
         (claims["authorization_details"]
             ?.let {

--- a/src/main/kotlin/no/mattilsynet/plantevernjournal/api/services/EppoService.kt
+++ b/src/main/kotlin/no/mattilsynet/plantevernjournal/api/services/EppoService.kt
@@ -1,6 +1,5 @@
 package no.mattilsynet.plantevernjournal.api.services
 
-import kotlinx.coroutines.runBlocking
 import no.mattilsynet.plantevernjournal.api.clients.EppoApiClient
 import no.mattilsynet.plantevernjournal.api.clients.models.EppoTaxon
 import no.mattilsynet.plantevernjournal.api.nats.consumers.EppoKvConsumer
@@ -12,12 +11,11 @@ class EppoService(
     private val eppoApiClient: EppoApiClient,
     private val eppoKvConsumer: EppoKvConsumer,
 ) {
-    fun getNavnFraEppoKode(eppoKode: String) =
-        runBlocking {
-            eppoKvConsumer.getEppoFraNats(eppoKode = eppoKode)
-                ?: eppoApiClient.getNavnFraEppoKode(eppoKode = eppoKode)
-                    ?.getPrioritertNavn()?.fullname
-        }?.also { eppoNavn ->
+    suspend fun getNavnFraEppoKode(eppoKode: String) =
+        eppoKvConsumer.getEppoFraNats(eppoKode = eppoKode)
+            ?: eppoApiClient.getNavnFraEppoKode(eppoKode = eppoKode)
+        ?.getPrioritertNavn()?.fullname
+        ?.also { eppoNavn ->
             eppoKvConsumer.putEppoTilNats(eppoNats = EppoNats(eppoKode = eppoKode, eppoNavn = eppoNavn))
         }
 

--- a/src/main/kotlin/no/mattilsynet/plantevernjournal/api/services/InnlesingService.kt
+++ b/src/main/kotlin/no/mattilsynet/plantevernjournal/api/services/InnlesingService.kt
@@ -17,7 +17,7 @@ class InnlesingService(
     private val natsService: NatsService,
 ) {
 
-    fun postFroeEllerFormeringsMateriale(
+    suspend fun postFroeEllerFormeringsMateriale(
         froeEllerFormeringsMatrialeDto: FroeEllerFormeringsMatrialeDto,
         innsender: String?,
         paaVegneAv: String?,
@@ -40,7 +40,7 @@ class InnlesingService(
                 }
             }
 
-    fun postInnendoersBruk(
+    suspend fun postInnendoersBruk(
         innendoersBrukDto: InnendoersBrukDto,
         innsender: String?,
         paaVegneAv: String?,
@@ -63,7 +63,7 @@ class InnlesingService(
                 }
             }
 
-    fun postUtendoersBruk(
+    suspend fun postUtendoersBruk(
         innsender: String?,
         paaVegneAv: String?,
         utendoersBrukDto: UtendoersBrukDto,
@@ -117,9 +117,8 @@ class InnlesingService(
         )
     }
 
-    private fun List<BehandletVekstDto>.validateEppokoder() =
-        true
-    /*     map { it.eppoKode }
+    private suspend fun List<BehandletVekstDto>.validateEppokoder() =
+         map { it.eppoKode }
              .filter { eppoKode ->
                  eppoService.getNavnFraEppoKode(eppoKode = eppoKode) == null
              }.takeIf { it.isNotEmpty() }
@@ -128,5 +127,4 @@ class InnlesingService(
                      eppoKoder.joinToString(", ") + " finnes ikke i eppodatabasen."
                  )
              }
- */
 }

--- a/src/test/kotlin/no/mattilsynet/plantevernjournal/api/controllers/PlantevernjournalInnlesingControllerTest.kt
+++ b/src/test/kotlin/no/mattilsynet/plantevernjournal/api/controllers/PlantevernjournalInnlesingControllerTest.kt
@@ -50,7 +50,7 @@ internal class PlantevernjournalInnlesingControllerTest {
     private lateinit var innlesingService: InnlesingService
 
     @Test
-    fun `postUtendoersBruk kaller videre paa innsendingService`() {
+    suspend fun `postUtendoersBruk kaller videre paa innsendingService`() {
         // Given:
         val utendoersBrukDtoMock = createUtendoersBrukDtoMock()
 
@@ -71,7 +71,7 @@ internal class PlantevernjournalInnlesingControllerTest {
     }
 
     @Test
-    fun `postInnendoersBruk kaller videre paa innsendingService`() {
+    suspend fun `postInnendoersBruk kaller videre paa innsendingService`() {
         // Given:
         val innendoersBrukDtoMock = createInnendoersBrukDtoMock()
 
@@ -92,7 +92,7 @@ internal class PlantevernjournalInnlesingControllerTest {
     }
 
     @Test
-    fun `postFroeEllerFormeringsMateriale kaller videre paa innsendingService`() {
+    suspend fun `postFroeEllerFormeringsMateriale kaller videre paa innsendingService`() {
         // Given:
         val froeEllerFormeringsMatrialeDtoMock = createFroeEllerFormeringsMaterialeDtoMock()
 

--- a/src/test/kotlin/no/mattilsynet/plantevernjournal/api/services/InnlesingServiceTest.kt
+++ b/src/test/kotlin/no/mattilsynet/plantevernjournal/api/services/InnlesingServiceTest.kt
@@ -1,6 +1,5 @@
 package no.mattilsynet.plantevernjournal.api.services
 
-import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.serialization.ExperimentalSerializationApi
 import no.mattilsynet.plantevernjournal.api.mocks.domain.SlettInnsendingMocker.createSlettInnsendingMock
 import no.mattilsynet.plantevernjournal.api.mocks.dto.FroeEllerFormeringsMatrialeDtoMocker.createFroeEllerFormeringsMaterialeDtoMock
@@ -9,10 +8,12 @@ import no.mattilsynet.plantevernjournal.api.mocks.dto.UtendoersBrukDtoMocker.cre
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalSerializationApi::class)
 internal class InnlesingServiceTest {
@@ -20,17 +21,20 @@ internal class InnlesingServiceTest {
     private lateinit var innlesingService: InnlesingService
 
     private val natsService = mock(NatsService::class.java)
+    private val eppoService = mock(EppoService::class.java)
 
     @BeforeEach
-    fun setUp() {
+    suspend fun setUp() {
         innlesingService = InnlesingService(
-            eppoService = mock(),
+            eppoService = eppoService,
             natsService = natsService,
         )
+
+        doReturn("Plantenavn").`when`(eppoService).getNavnFraEppoKode(any())
     }
 
     @Test
-    fun `postFroeEllerFormeringsMateriale poster til nats og returnerer opprettet og id`() {
+    suspend fun `postFroeEllerFormeringsMateriale poster til nats og returnerer opprettet og id`() {
         // Given:
         val froeEllerFormeringsMatrialeDtoMock = createFroeEllerFormeringsMaterialeDtoMock()
 
@@ -51,7 +55,7 @@ internal class InnlesingServiceTest {
     }
 
     @Test
-    fun `postInnendoersBruk poster til nats og returnerer opprettet og id`() {
+    suspend fun `postInnendoersBruk poster til nats og returnerer opprettet og id`() {
         // Given:
         val innendoersBrukDtoMock = createInnendoersBrukDtoMock()
 
@@ -72,7 +76,7 @@ internal class InnlesingServiceTest {
     }
 
     @Test
-    fun `postUtendoersBruk poster til nats og returnerer opprettet og id`() {
+    suspend fun `postUtendoersBruk poster til nats og returnerer opprettet og id`() {
         // Given:
         val utendoersBrukDto = createUtendoersBrukDtoMock()
 


### PR DESCRIPTION
WebClient (reaktiv/asynkron) ble kalt fra en blokkerende… Spring MVC-tråd. Under last førte dette til at reactor-tråder ble blokkert, som ga timeout.

Løsningen var å gjøre hele kallkjeden til suspend-funksjoner med coroutines, slik at tråder frigjøres mens du venter på svar fra EPPO-APIet.